### PR TITLE
Improvement/topic 43 fix integration tests

### DIFF
--- a/src/API/Controllers/DatabaseController.cs
+++ b/src/API/Controllers/DatabaseController.cs
@@ -73,7 +73,6 @@ namespace BadMelon.API.Controllers
                 {
                     var us = await _db.Users.SingleOrDefaultAsync(x => x.UserName == u.Item1.UserName);
                     var resultx = await _userManager.AddPasswordAsync(us, u.Item2.Password);
-                    Console.WriteLine("there");
                 }
             }
             catch (Exception e)

--- a/src/API/Startup.cs
+++ b/src/API/Startup.cs
@@ -48,7 +48,6 @@ namespace BadMelon.API
 
             services.AddDbContext<BadMelonDataContext>(options =>
                     options
-                    .UseLazyLoadingProxies()
                     .UseNpgsql(dbConnectionString));
 
             services.AddHttpContextAccessor();

--- a/src/Data/BadMelonDataContext.cs
+++ b/src/Data/BadMelonDataContext.cs
@@ -23,7 +23,6 @@ namespace BadMelon.Data
 
         public async Task Seed()
         {
-            await Database.MigrateAsync();
             if (!await Users.AnyAsync())
             {
                 var data = new DataSamples();

--- a/src/Data/DataSamples.cs
+++ b/src/Data/DataSamples.cs
@@ -91,7 +91,7 @@ namespace BadMelon.Data
                 RecipeId = coldWater.ID
             });
 
-            _Recipes = new List<Recipe> { cornSoup, hotWater, coldWater };
+            _Recipes = new List<Recipe> { cornSoup, coldWater, hotWater };
         }
 
         public void AddRecipeToStorage(Recipe recipe)

--- a/src/Data/Entities/Recipe.cs
+++ b/src/Data/Entities/Recipe.cs
@@ -3,7 +3,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace BadMelon.Data.Entities
 {
-    public class Recipe : Entity
+    public class Recipe : UserPermittedEntity
     {
         [Required]
         [StringLength(100)]
@@ -12,8 +12,5 @@ namespace BadMelon.Data.Entities
         public virtual ICollection<Step> Steps { get; set; }
 
         public virtual ICollection<Ingredient> Ingredients { get; set; }
-
-        public string UserId { get; set; }
-        public virtual User User { get; set; }
     }
 }

--- a/src/Data/Entities/UserPermittedEntity.cs
+++ b/src/Data/Entities/UserPermittedEntity.cs
@@ -1,0 +1,8 @@
+﻿namespace BadMelon.Data.Entities
+{
+    public abstract class UserPermittedEntity : Entity
+    {
+        public string UserId { get; set; }
+        public virtual User User { get; set; }
+    }
+}

--- a/src/Data/Exceptions/EntityNotFoundException.cs
+++ b/src/Data/Exceptions/EntityNotFoundException.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BadMelon.Data.Entities;
+using System;
 
 namespace BadMelon.Data.Exceptions
 {
@@ -6,12 +7,23 @@ namespace BadMelon.Data.Exceptions
     {
         private const string messagePrefix = "Could not find ";
 
+        public EntityNotFoundException(Type t) : base(messagePrefix + TranslateTypeToString(t))
+        {
+        }
+
         public EntityNotFoundException(string message) : base(messagePrefix + message)
         {
         }
 
         public EntityNotFoundException(string message, System.Exception innerException) : base(messagePrefix + message, innerException)
         {
+        }
+
+        private static string TranslateTypeToString(Type t)
+        {
+            if (t == typeof(IngredientType))
+                return "ingredient type";
+            return "entity";
         }
     }
 }

--- a/src/Data/Services/CrudServiceAbstract.cs
+++ b/src/Data/Services/CrudServiceAbstract.cs
@@ -1,0 +1,64 @@
+﻿using BadMelon.Data.Entities;
+using BadMelon.Data.Exceptions;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace BadMelon.Data.Services
+{
+    public abstract class CrudServiceAbstract<T> : ICrudService<T> where T : Entity
+    {
+        protected readonly BadMelonDataContext _db;
+
+        public CrudServiceAbstract(BadMelonDataContext db)
+        {
+            _db = db;
+        }
+
+        public virtual async Task<T> GetOne(Guid id)
+        {
+            var entity = await _db.Set<T>().SingleOrDefaultAsync(t => t.ID == id);
+            if (entity == default(T))
+                throw new EntityNotFoundException(typeof(T));
+            return entity;
+        }
+
+        public async Task AddMany(ICollection<T> models)
+        {
+            await _db.Set<T>().AddRangeAsync(models);
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task AddOne(T model)
+        {
+            await _db.Set<T>().AddAsync(model);
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task Delete(T model)
+        {
+            _db.Set<T>().Remove(model);
+            await _db.SaveChangesAsync();
+        }
+
+        public async Task Delete(Guid id)
+        {
+            var entity = await GetOne(id);
+            await Delete(entity);
+        }
+
+        public async Task<T[]> GetAll()
+        {
+            return await _db.Set<T>().ToArrayAsync();
+        }
+
+        //TODO: Check if this works
+        public async Task<T> Update(T model)
+        {
+            _db.Set<T>().Update(model);
+            await _db.SaveChangesAsync();
+            return model;
+        }
+    }
+}

--- a/src/Data/Services/ICrudService.cs
+++ b/src/Data/Services/ICrudService.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace BadMelon.Data.Services
+{
+    public interface ICrudService<T>
+    {
+        Task<T> GetOne(Guid id);
+
+        Task<T[]> GetAll();
+
+        Task AddOne(T model);
+
+        Task AddMany(ICollection<T> models);
+
+        Task<T> Update(T model);
+
+        Task Delete(T model);
+
+        Task Delete(Guid id);
+    }
+}

--- a/src/Data/Services/IUserService.cs
+++ b/src/Data/Services/IUserService.cs
@@ -11,7 +11,7 @@ namespace BadMelon.Data.Services
 
         Task<bool> Login(Guid code);
 
-        Task<User> GetLoggedInUser();
+        User GetLoggedInUser();
 
         Task<bool> IsLoggedIn();
 

--- a/src/Data/Services/IngredientTypeService.cs
+++ b/src/Data/Services/IngredientTypeService.cs
@@ -1,39 +1,28 @@
 ﻿using BadMelon.Data.DTOs;
-using BadMelon.Data.Exceptions;
-using BadMelon.Data.Helpers;
-using Microsoft.EntityFrameworkCore;
 using System;
 using System.Threading.Tasks;
 
 namespace BadMelon.Data.Services
 {
-    public class IngredientTypeService : IIngredientTypeService
+    public class IngredientTypeService : CrudServiceAbstract<Entities.IngredientType>, IIngredientTypeService
     {
-        private readonly BadMelonDataContext _db;
-
-        public IngredientTypeService(BadMelonDataContext db)
+        public IngredientTypeService(BadMelonDataContext db) : base(db)
         {
-            _db = db;
         }
 
         public async Task<IngredientType> GetIngredientType(Guid id)
         {
-            var ingredientType = await _db.IngredientTypes.SingleOrDefaultAsync(it => it.ID == id);
-            if (ingredientType == null)
-                throw new EntityNotFoundException("ingredient type");
+            var ingredientType = await GetOne(id);
             return ingredientType.ConvertToDTO();
         }
 
-        public async Task<IngredientType[]> GetIngredientTypes() => (await _db.IngredientTypes.ToArrayAsync())?.ConvertToDTO();
+        public async Task<IngredientType[]> GetIngredientTypes() => (await GetAll()).ConvertToDTO();
 
         public async Task<IngredientType> AddIngredientType(IngredientType ingredientType)
         {
             var ingredientTypeEntity = ingredientType.ConvertToEntity();
-            var newIngredientType = _db.IngredientTypes.CreateProxy();
-            EntityCopier.Copy(ingredientTypeEntity, newIngredientType);
-            await _db.IngredientTypes.AddAsync(newIngredientType);
-            await _db.SaveChangesAsync();
-            return newIngredientType.ConvertToDTO();
+            await AddOne(ingredientTypeEntity);
+            return ingredientTypeEntity.ConvertToDTO();
         }
     }
 }

--- a/src/Data/Services/UserService.cs
+++ b/src/Data/Services/UserService.cs
@@ -38,9 +38,9 @@ namespace BadMelon.Data.Services
             _logger = logger;
         }
 
-        public async Task<User> GetLoggedInUser()
+        public User GetLoggedInUser()
         {
-            var user = await _userManager.GetUserAsync(_httpContext.HttpContext.User);
+            var user = _userManager.GetUserAsync(_httpContext.HttpContext.User).Result;
             if (user == null)
                 throw new UnauthorizedException();
             return user;
@@ -148,7 +148,7 @@ Bad Melon Admin");
 
         public async Task Reset(PasswordReset reset)
         {
-            var user = await GetLoggedInUser();
+            var user = GetLoggedInUser();
             if (!user.IsPasswordSet)
             {
                 var passwordResult = await _userManager.AddPasswordAsync(user, reset.NewPassword);

--- a/tests/Controllers/AccountControllerTests.cs
+++ b/tests/Controllers/AccountControllerTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace BadMelon.Tests.Controllers
 {
-    [Collection("SynchronousTests")]
+    [Collection("Controller collection")]
     public class AccountControllerTests : ControllerTestsFixture
     {
         public AccountControllerTests() : base()

--- a/tests/Controllers/AuthControllerTests.cs
+++ b/tests/Controllers/AuthControllerTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace BadMelon.Tests.Controllers
 {
-    [Collection("SynchronousTests")]
+    [Collection("Controller collection")]
     public class AuthControllerTests : ControllerTestsFixture
     {
         private string GoodLongPassword = "long enough password to not be complex";

--- a/tests/Controllers/IngredientTypeControllerTests.cs
+++ b/tests/Controllers/IngredientTypeControllerTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace BadMelon.Tests.Controllers
 {
-    [Collection("SynchronousTests")]
+    [Collection("Controller collection")]
     public class IngredientTypeControllerTests : ControllerTestsFixture
     {
         [Fact]

--- a/tests/Controllers/RecipeControllerTests.cs
+++ b/tests/Controllers/RecipeControllerTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace BadMelon.Tests.Controllers
 {
-    [Collection("SynchronousTests")]
+    [Collection("Controller collection")]
     public class RecipeControllerTests : ControllerTestsFixture
     {
         [Fact]

--- a/tests/Fixtures/ControllerCollection.cs
+++ b/tests/Fixtures/ControllerCollection.cs
@@ -1,0 +1,9 @@
+﻿using Xunit;
+
+namespace BadMelon.Tests.Fixtures
+{
+    [CollectionDefinition("Controller collection")]
+    public class ControllerCollection : ICollectionFixture<ControllerTestsFixture>
+    {
+    }
+}

--- a/tests/Fixtures/ControllerTestsFixture.cs
+++ b/tests/Fixtures/ControllerTestsFixture.cs
@@ -21,7 +21,7 @@ namespace BadMelon.Tests.Fixtures
             _http.BaseAddress = testClient.BaseAddress;
             dataSamples = new DataSamples();
 
-            _http.DeleteAsync("api/database").Wait();
+            AsyncHelper.RunSync(() => _http.DeleteAsync("api/database"));
             Login();
         }
 

--- a/tests/TestServerFactory.cs
+++ b/tests/TestServerFactory.cs
@@ -7,6 +7,14 @@ namespace BadMelon.Tests
 {
     internal class TestServerFactory
     {
-        public static TestServer GetTestServer() => new TestServer(WebHost.CreateDefaultBuilder().UseStartup<TestStartup>().UseSerilog().UseEnvironment("Testing"));
+        private static TestServer testServer = null;
+
+        public static TestServer GetTestServer()
+        {
+            if (testServer == null)
+                testServer = new TestServer(WebHost.CreateDefaultBuilder().UseStartup<TestStartup>().UseSerilog().UseEnvironment("Testing"));
+
+            return testServer;
+        }
     }
 }

--- a/tests/TestStartup.cs
+++ b/tests/TestStartup.cs
@@ -30,11 +30,7 @@ namespace BadMelon.Tests
                     throw new Exception("LIVE SETTINGS IN TESTS!");
                 }
 
-                dbContext.Database.EnsureDeletedAsync().Wait();
                 base.Configure(app);
-
-                // Initialize database
-                dbContext.Seed().Wait();
             }
         }
 


### PR DESCRIPTION
Removed lazy loading and added some abstractions to handle simple crud situations.

Improved database seeding setup by removing redundancies and going with a simpler approach.

This change decreased test time by >50%. However there should be a way that each controller test suite could have its own in-memory database and run in parallel, further improving performance.