### PR TITLE
Fixed Test Project Startup Issue

### DIFF
--- a/src/API/BadMelon.API.csproj
+++ b/src/API/BadMelon.API.csproj
@@ -25,7 +25,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Client\BadMelon.Client.csproj" />
 		<ProjectReference Include="..\Data\BadMelon.Data.csproj" />
 	</ItemGroup>
 

--- a/tests/TestStartup.cs
+++ b/tests/TestStartup.cs
@@ -17,7 +17,7 @@ namespace BadMelon.Tests
         {
         }
 
-        public override void Configure(IApplicationBuilder app)
+        public override void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             var serviceScopeFactory = app.ApplicationServices.GetRequiredService<IServiceScopeFactory>();
             using (var serviceScope = serviceScopeFactory.CreateScope())
@@ -30,7 +30,7 @@ namespace BadMelon.Tests
                     throw new Exception("LIVE SETTINGS IN TESTS!");
                 }
 
-                base.Configure(app);
+                base.Configure(app, env);
             }
         }
 


### PR DESCRIPTION
Removed reference to the old blazor client project. Updated test startup to use the IWebHostEnvironment the same as the regular startup.